### PR TITLE
Minor change for finding files .

### DIFF
--- a/scripts/lint-all.sh
+++ b/scripts/lint-all.sh
@@ -9,7 +9,7 @@
 path=`pwd`
 cd `git rev-parse --show-toplevel`
 
-files=`find . -name "*.js" -not -regex "^\./node_modules\(.*\)"`
+files=`find . ! -wholename '*/node_modules/*' -name '*.js'`
 
 if [[ -z "$files" ]]
 then


### PR DESCRIPTION
a) easier to read
b) easier to add multime exceptions. For example;
    files=`find . ! -wholename '*/modules/*' ! -wholename '*/node_modules/*' -name '*.js'`
