### PR TITLE
Clearer error output

### DIFF
--- a/tomes.js
+++ b/tomes.js
@@ -185,7 +185,7 @@ Tome.resolveChain = function (tome, chain) {
 	for (var i = 0; i < len; i += 1) {
 		var link = chain[i];
 		if (!target.hasOwnProperty(link)) {
-			throw new ReferenceError('resolveChain - Error resolving chain.' + chain);
+			throw new ReferenceError('resolveChain - Error resolving chain: ' + chain);
 		}
 		target = target[link];
 	}


### PR DESCRIPTION
The period there (and lacking space) made the word "chain" look as part of the chain.
