### PR TITLE
Replaced isTome with something more cross browser compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -530,8 +530,14 @@ Tome.isTome = function (o) {
 		return true;
 	}
 
+	var proto;
 	// Getting the prototype's prototype's of the object
-	var proto = Object.getPrototypeOf(Object.getPrototypeOf(o));
+	// Recent browsers use the folowing method instead of the getter `__proto__`
+	if (Object.hasOwnProperty('getPrototypeOf')) {
+		proto = Object.getPrototypeOf(Object.getPrototypeOf(o));
+	} else {
+		proto = o.__proto__ && o.__proto__.__proto__;
+	}
 	if (!proto || !proto.constructor) {
 		return false;
 	}


### PR DESCRIPTION
Doing an early return (`false`) if it's not even an object.
Doing an early return (`true`) if it inherit from the current Tome.
Using now `Object.getPrototypeOf` instead of accessing `__proto__` which is deprecated.
Using a work around to get the name of the constructor if the property `name` doesn't exist.
