### PR TITLE
Rewrite root when removing ObjectTome from ArrayTome

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,45 @@ function reset(tome) {
 	}
 }
 
+function setRoot(tome, root) {
+	// When an ObjectTome is removed from his parent (like when using ArrayTome.shift)
+	// we need to update his root/parent as well as all the childs so that changes
+	// made to that item do not propagate to the ArrayTome anymore
+	if (!tome) {
+		return;
+	}
+
+	tome.__root__ = root;
+
+	if (tome === root) {
+		delete(tome.__key__);
+		delete(tome.__parent__);
+
+		// if we are the root, also update us to have a diff
+		Object.defineProperties(tome, {
+			__diff__: { writable: true, value: [] },
+			__version__: { writable: true, value: 1 }
+		});
+	}
+
+	// recursively update values
+	if (ObjectTome.isObjectTome(tome)) {
+		var keys = Object.keys(tome);
+		var len = keys.length;
+		var key;
+
+		for (var i = 0; i < len; i += 1) {
+			key = keys[i];
+
+			var kv = tome[key];
+
+			if (Tome.isTome(kv)) {
+				setRoot(kv, root);
+			}
+		}
+	}
+}
+
 Tome.resolveChain = function (tome, chain) {
 	var len = chain.length;
 	var target = tome.__root__;
@@ -1276,6 +1315,9 @@ ArrayTome.prototype.shift = function () {
 		diff(this, 'shift');
 	}
 
+	// update root
+	setRoot(out, out);
+
 	return out ? out.valueOf() : out;
 };
 
@@ -1299,6 +1341,8 @@ ArrayTome.prototype.pop = function () {
 		emitDel(this, len);
 		diff(this, 'pop');
 	}
+
+	setRoot(out, out);
 
 	return out ? out.valueOf() : out;
 };
@@ -1381,6 +1425,7 @@ ArrayTome.prototype.splice = function (spliceIndex, toRemove) {
 		for (i = 0, len = out.length; i < len; i += 1) {
 			key = this._arr.length + i;
 			delete this[key];
+			setRoot(out[i], out[i]);
 		}
 	}
 

--- a/test/modules/array.js
+++ b/test/modules/array.js
@@ -1210,14 +1210,16 @@ exports.moveRootIntoItself = function (test) {
 };
 
 exports.rewriteRootOnRemove = function (test) {
-	test.expect(3);
+	test.expect(4);
 
-	var a = Tome.conjure([{}, {}, {}, {}, {}, {}]);
+	var a = Tome.conjure([{ bar: {} }, {}, {}, {}, {}, {}]);
 	var b = a.shift(); a.readAll();
 
 	b.set('foo', 'bar');
+	b.bar.set('foo', 'bar');
 
 	test.strictEqual(a.readAll().length, 0);
+	test.strictEqual(b.readAll().length, 2);
 
 	var c = a.splice(2, 2); a.readAll();
 	c[0].set('foo', 'bar');

--- a/test/modules/array.js
+++ b/test/modules/array.js
@@ -1208,3 +1208,27 @@ exports.moveRootIntoItself = function (test) {
 
 	test.done();
 };
+
+exports.rewriteRootOnRemove = function (test) {
+	test.expect(3);
+
+	var a = Tome.conjure([{}, {}, {}, {}, {}, {}]);
+	var b = a.shift(); a.readAll();
+
+	b.set('foo', 'bar');
+
+	test.strictEqual(a.readAll().length, 0);
+
+	var c = a.splice(2, 2); a.readAll();
+	c[0].set('foo', 'bar');
+	c[1].set('foo', 'bar');
+
+	test.strictEqual(a.readAll().length, 0);
+
+	var d = a.pop(); a.readAll();
+	d.set('foo', 'bar');
+
+	test.strictEqual(a.readAll().length, 0);
+
+	test.done();
+};


### PR DESCRIPTION
When an `ObjectTome` is removed from an `ArrayTome` the root would not be rewritten on the object, meaning that any change to the object itself or it's values would propagate to the array and break diffs due to invalid chains.
