### PR TITLE
Allow passing a previous snapshot to takeSnapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ Returns a boolean value indicating whether or not the Tome is observably indisti
 ###isDirty( )
 Returns whether a Tome has been changed, but the change has not been read.
 
-###takeSnapshot( )
-Returns a snapshot object of the root Tome.
+###takeSnapshot( [ *snapshot* ] )
+Returns a snapshot object of the root Tome. If you pass a previously made snapshot, it may be returned instead of a
+fresh snapshot, if the Tome has not changed in the mean time.
 
 ###restoreSnapshot( *snapshot* )
 

--- a/index.js
+++ b/index.js
@@ -638,9 +638,13 @@ Tome.prototype.getParent = function () {
 	return this.__parent__;
 };
 
-Tome.prototype.takeSnapshot = function () {
+Tome.prototype.takeSnapshot = function (existingSnapshot) {
 	if (this.__root__ !== this) {
 		throw new Error('Only root tomes can take snapshots');
+	}
+
+	if (existingSnapshot && existingSnapshot.version === this.__version__) {
+		return existingSnapshot;
 	}
 
 	return {

--- a/test/modules/snapshots.js
+++ b/test/modules/snapshots.js
@@ -15,6 +15,11 @@ exports.testSnapshot = function (test) {
 
 	test.deepEqual(snapshot2, snapshot);
 
+	// passing an old snapshot to an unchanged tome should return that snapshot
+
+	var snapshot3 = b.takeSnapshot(snapshot2);
+	test.strictEqual(snapshot3, snapshot2);
+
 	// check the state of the snapshot
 
 	test.deepEqual(snapshot.content, c);


### PR DESCRIPTION
Closes #51 

From the readme:

### takeSnapshot( [ *snapshot* ] )
Returns a snapshot object of the root Tome. If you pass a previously made snapshot, it may be returned instead of a fresh snapshot, if the Tome has not changed in the mean time.