### PR TITLE
More property issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,8 @@ var conjure;
 
 // a special hasOwnProperty function so we can override the built-in one
 
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-
-function hop(obj, propName) {
-	return hasOwnProperty.call(obj, propName);
+function hasOwnProperty(obj, propName) {
+	return Object.prototype.hasOwnProperty.call(obj, propName);
 }
 
 //  ________
@@ -190,7 +188,7 @@ Tome.resolveChain = function (tome, chain) {
 
 	for (var i = 0; i < len; i += 1) {
 		var link = chain[i];
-		if (!hop(target, link)) {
+		if (!hasOwnProperty(target, link)) {
 			throw new ReferenceError('resolveChain - Error resolving chain: ' + chain);
 		}
 		target = target[link];
@@ -202,7 +200,7 @@ Tome.resolveChain = function (tome, chain) {
 Tome.buildChain = function (tome) {
 	var chain = [];
 
-	while (hop(tome, '__key__')) {
+	while (hasOwnProperty(tome, '__key__')) {
 		chain.push(tome.__key__);
 		tome = tome.__parent__;
 	}
@@ -271,7 +269,7 @@ function markDirty(tome, dirtyAt, was) {
 
 	tome.emit('readable', was);
 
-	if (hop(tome, '__parent__')) {
+	if (hasOwnProperty(tome, '__parent__')) {
 		markDirty(tome.__parent__, dirtyAt);
 	}
 }
@@ -307,11 +305,11 @@ function arrayInit(tome, val, seen) {
 	//  -   _arr: Holds the actual array that we reference.
 	//  - length: Holds the length of the array in _arr.
 
-	if (!hop(tome, '_arr')) {
+	if (!hasOwnProperty(tome, '_arr')) {
 		Object.defineProperty(tome, '_arr', { configurable: true, writable: true });
 	}
 
-	if (!hop(tome, 'length')) {
+	if (!hasOwnProperty(tome, 'length')) {
 		Object.defineProperty(tome, 'length', { configurable: true, writable: true });
 	}
 
@@ -354,7 +352,7 @@ function arrayInit(tome, val, seen) {
 		// have elements, but no keys ie. new Array(1) is different from
 		// [undefined].
 
-		if (hop(val, i)) {
+		if (hasOwnProperty(val, i)) {
 			tome[i] = tome._arr[i];
 		}
 	}
@@ -433,7 +431,7 @@ function objectInit(tome, val, seen) {
 }
 
 function primitiveInit(tome, val) {
-	if (!hop(tome, '_val')) {
+	if (!hasOwnProperty(tome, '_val')) {
 		Object.defineProperty(tome, '_val', { configurable: true, writable: true });
 	}
 
@@ -722,7 +720,7 @@ Tome.prototype.set = function (key, val) {
 		this.__proto__ = ObjectTome.prototype;
 	}
 
-	if (!hop(this, key)) {
+	if (!hasOwnProperty(this, key)) {
 
 		// This is a new property, we conjure a new Tome with a type based on
 		// the type of the value and assign it to the property. Then we emit an
@@ -843,7 +841,7 @@ Tome.prototype.del = function (key) {
 	// also signal that it was changed which also signals all the way up the
 	// Tome chain.
 
-	if (!hop(this, key)) {
+	if (!hasOwnProperty(this, key)) {
 		throw new ReferenceError('Tome.del - Key is not defined: ' + key);
 	}
 
@@ -864,7 +862,7 @@ Tome.prototype.del = function (key) {
 };
 
 Tome.prototype.move = function (key, newParent, onewKey) {
-	if (!hop(this, key)) {
+	if (!hasOwnProperty(this, key)) {
 		throw new ReferenceError('Tome.move - Key is not defined: ' + key);
 	}
 
@@ -1063,7 +1061,7 @@ Tome.prototype.merge = function (diff) {
 };
 
 Tome.prototype.swap = function (key, target) {
-	if (!hop(this, key)) {
+	if (!hasOwnProperty(this, key)) {
 		throw new ReferenceError('Tome.swap - Key is not defined: ' + key);
 	}
 
@@ -1071,7 +1069,7 @@ Tome.prototype.swap = function (key, target) {
 		throw new TypeError('Tome.swap - Target must be a Tome');
 	}
 
-	if (!hop(target, '__parent__')) {
+	if (!hasOwnProperty(target, '__parent__')) {
 		throw new ReferenceError('Tome.swap - Cannot swap to a root Tome');
 	}
 
@@ -1160,7 +1158,7 @@ ArrayTome.prototype.hasOwnProperty = function (key) {
 		return false;
 	}
 
-	return hop(this, key);
+	return hasOwnProperty(this, key);
 };
 
 ArrayTome.prototype.join = function (separator) {
@@ -1228,7 +1226,7 @@ ArrayTome.prototype.set = function (okey, val) {
 };
 
 ArrayTome.prototype.del = function (key) {
-	if (!hop(this, key)) {
+	if (!hasOwnProperty(this, key)) {
 		throw new ReferenceError('ArrayTome.del - Key is not defined: ' + key);
 	}
 
@@ -1415,7 +1413,7 @@ ArrayTome.prototype.rename = function () {
 
 	for (oldKey in rO) {
 		newKey = rO[oldKey];
-		if (!hop(this, oldKey)) {
+		if (!hasOwnProperty(this, oldKey)) {
 			throw new ReferenceError('ObjectTome.rename - Key is not defined: ' + oldKey);
 		}
 
@@ -1839,7 +1837,7 @@ ObjectTome.prototype.rename = function () {
 	for (var oldKey in rO) {
 		var newKey = rO[oldKey];
 
-		if (!hop(this, oldKey)) {
+		if (!hasOwnProperty(this, oldKey)) {
 			throw new ReferenceError('ObjectTome.rename - Key is not defined: ' + oldKey);
 		}
 
@@ -1957,7 +1955,7 @@ function inheritClassMethods() {
 
 		for (var i = 0; i < methods.length; i += 1) {
 			var k = methods[i];
-			if (!hop(t.prototype, k)) {
+			if (!hasOwnProperty(t.prototype, k)) {
 				t.prototype[k] = c.prototype[k];
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -44,6 +44,14 @@ var isArray = Array.isArray;
 // interdependence between different functions.
 var conjure;
 
+// a special hasOwnProperty function so we can override the built-in one
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function hop(obj, propName) {
+	return hasOwnProperty.call(obj, propName);
+}
+
 //  ________
 // |        \
 //  \$$$$$$$$______   ______ ____    ______    _______
@@ -182,7 +190,7 @@ Tome.resolveChain = function (tome, chain) {
 
 	for (var i = 0; i < len; i += 1) {
 		var link = chain[i];
-		if (!target.hasOwnProperty(link)) {
+		if (!hop(target, link)) {
 			throw new ReferenceError('resolveChain - Error resolving chain: ' + chain);
 		}
 		target = target[link];
@@ -194,7 +202,7 @@ Tome.resolveChain = function (tome, chain) {
 Tome.buildChain = function (tome) {
 	var chain = [];
 
-	while (tome.hasOwnProperty('__key__')) {
+	while (hop(tome, '__key__')) {
 		chain.push(tome.__key__);
 		tome = tome.__parent__;
 	}
@@ -263,7 +271,7 @@ function markDirty(tome, dirtyAt, was) {
 
 	tome.emit('readable', was);
 
-	if (tome.hasOwnProperty('__parent__')) {
+	if (hop(tome, '__parent__')) {
 		markDirty(tome.__parent__, dirtyAt);
 	}
 }
@@ -299,11 +307,11 @@ function arrayInit(tome, val, seen) {
 	//  -   _arr: Holds the actual array that we reference.
 	//  - length: Holds the length of the array in _arr.
 
-	if (!tome.hasOwnProperty('_arr')) {
+	if (!hop(tome, '_arr')) {
 		Object.defineProperty(tome, '_arr', { configurable: true, writable: true });
 	}
 
-	if (!tome.hasOwnProperty('length')) {
+	if (!hop(tome, 'length')) {
 		Object.defineProperty(tome, 'length', { configurable: true, writable: true });
 	}
 
@@ -346,7 +354,7 @@ function arrayInit(tome, val, seen) {
 		// have elements, but no keys ie. new Array(1) is different from
 		// [undefined].
 
-		if (val.hasOwnProperty(i)) {
+		if (hop(val, i)) {
 			tome[i] = tome._arr[i];
 		}
 	}
@@ -425,7 +433,7 @@ function objectInit(tome, val, seen) {
 }
 
 function primitiveInit(tome, val) {
-	if (!tome.hasOwnProperty('_val')) {
+	if (!hop(tome, '_val')) {
 		Object.defineProperty(tome, '_val', { configurable: true, writable: true });
 	}
 
@@ -525,7 +533,7 @@ Tome.isTome = function (o) {
 	var proto;
 	// Getting the prototype's prototype's of the object
 	// Recent browsers use the folowing method instead of the getter `__proto__`
-	if (Object.hasOwnProperty('getPrototypeOf')) {
+	if (Object.getPrototypeOf) {
 		proto = Object.getPrototypeOf(Object.getPrototypeOf(o));
 	} else {
 		proto = o.__proto__ && o.__proto__.__proto__;
@@ -714,7 +722,7 @@ Tome.prototype.set = function (key, val) {
 		this.__proto__ = ObjectTome.prototype;
 	}
 
-	if (!this.hasOwnProperty(key)) {
+	if (!hop(this, key)) {
 
 		// This is a new property, we conjure a new Tome with a type based on
 		// the type of the value and assign it to the property. Then we emit an
@@ -775,7 +783,7 @@ Tome.prototype.assign = function (val) {
 		throw new TypeError('Tome.assign - Invalid value type: ' + vType);
 	}
 
-	if (vType === 'undefined' && (!this.hasOwnProperty('__parent__') || this.__parent__.typeOf() !== 'array')) {
+	if (vType === 'undefined' && (!this.__parent__ || this.__parent__.typeOf() !== 'array')) {
 		throw new TypeError('Tome.assign - You can only assign undefined to ArrayTome elements');
 	}
 
@@ -835,7 +843,7 @@ Tome.prototype.del = function (key) {
 	// also signal that it was changed which also signals all the way up the
 	// Tome chain.
 
-	if (!this.hasOwnProperty(key)) {
+	if (!hop(this, key)) {
 		throw new ReferenceError('Tome.del - Key is not defined: ' + key);
 	}
 
@@ -856,7 +864,7 @@ Tome.prototype.del = function (key) {
 };
 
 Tome.prototype.move = function (key, newParent, onewKey) {
-	if (!this.hasOwnProperty(key)) {
+	if (!hop(this, key)) {
 		throw new ReferenceError('Tome.move - Key is not defined: ' + key);
 	}
 
@@ -1055,7 +1063,7 @@ Tome.prototype.merge = function (diff) {
 };
 
 Tome.prototype.swap = function (key, target) {
-	if (!this.hasOwnProperty(key)) {
+	if (!hop(this, key)) {
 		throw new ReferenceError('Tome.swap - Key is not defined: ' + key);
 	}
 
@@ -1063,7 +1071,7 @@ Tome.prototype.swap = function (key, target) {
 		throw new TypeError('Tome.swap - Target must be a Tome');
 	}
 
-	if (!target.hasOwnProperty('__parent__')) {
+	if (!hop(target, '__parent__')) {
 		throw new ReferenceError('Tome.swap - Cannot swap to a root Tome');
 	}
 
@@ -1142,6 +1150,19 @@ ArrayTome.prototype.typeOf = function () {
 	return 'array';
 };
 
+ArrayTome.prototype.hasOwnProperty = function (key) {
+	// because of issues in V8 with enumerable non-enumerables, we use this workaround to allow the
+	// "for-in with hasOwnProperty" loop to work.
+	// See: https://bugs.chromium.org/p/v8/issues/detail?id=4905
+
+	key = String(key);
+	if (!key.match(/^[0-9]+$/)) {
+		return false;
+	}
+
+	return hop(this, key);
+};
+
 ArrayTome.prototype.join = function (separator) {
 	var out = '';
 	var len = this._arr.length;
@@ -1207,7 +1228,7 @@ ArrayTome.prototype.set = function (okey, val) {
 };
 
 ArrayTome.prototype.del = function (key) {
-	if (!this.hasOwnProperty(key)) {
+	if (!hop(this, key)) {
 		throw new ReferenceError('ArrayTome.del - Key is not defined: ' + key);
 	}
 
@@ -1394,7 +1415,7 @@ ArrayTome.prototype.rename = function () {
 
 	for (oldKey in rO) {
 		newKey = rO[oldKey];
-		if (!this.hasOwnProperty(oldKey)) {
+		if (!hop(this, oldKey)) {
 			throw new ReferenceError('ObjectTome.rename - Key is not defined: ' + oldKey);
 		}
 
@@ -1783,6 +1804,14 @@ ObjectTome.prototype.toJSON = function () {
 	return out;
 };
 
+ObjectTome.prototype.hasOwnProperty = function (key) {
+	// because of issues in V8 with enumerable non-enumerables, we use this workaround to allow the
+	// "for-in with hasOwnProperty" loop to work.
+	// See: https://bugs.chromium.org/p/v8/issues/detail?id=4905
+
+	return Object.keys(this).indexOf(key) !== -1;
+};
+
 ObjectTome.prototype.rename = function () {
 
 	// ObjectTome.rename can take a few different styles of arguments:
@@ -1810,7 +1839,7 @@ ObjectTome.prototype.rename = function () {
 	for (var oldKey in rO) {
 		var newKey = rO[oldKey];
 
-		if (!this.hasOwnProperty(oldKey)) {
+		if (!hop(this, oldKey)) {
 			throw new ReferenceError('ObjectTome.rename - Key is not defined: ' + oldKey);
 		}
 
@@ -1925,11 +1954,10 @@ function inheritClassMethods() {
 		var t = tomeMap[ck]; // tome
 
 		var methods = Object.getOwnPropertyNames(c.prototype);
-		var len = methods.length;
 
-		for (var i = 0; i < len; i += 1) {
+		for (var i = 0; i < methods.length; i += 1) {
 			var k = methods[i];
-			if (!t.prototype.hasOwnProperty(k)) {
+			if (!hop(t.prototype, k)) {
 				t.prototype[k] = c.prototype[k];
 			}
 		}

--- a/test/modules/array.js
+++ b/test/modules/array.js
@@ -43,9 +43,15 @@ exports.testArrayCreation = function (test) {
 };
 
 exports.testArrayCreation2 = function (test) {
-	test.expect(5);
 	var a = [];
 	var b = Tome.conjure(a);
+
+	for (var key in b) {
+		if (b.hasOwnProperty(key)) {
+			test.ok(false, 'No enumerable own properties expected, but found: ' + key);
+		}
+	}
+
 	test.ok(JSON.stringify(a) === JSON.stringify(b), 'JSON.stringify failure: ' + JSON.stringify(a) + '!==' + JSON.stringify(b));
 	a[0] = 0;
 	b.set(0, 0);

--- a/test/modules/array.js
+++ b/test/modules/array.js
@@ -22,9 +22,15 @@ var notInstanceOf = function (actual, expected) {
 };
 
 exports.testArrayCreation = function (test) {
-	test.expect(14);
 	var a = [1, 2, 3, 4];
 	var b = Tome.conjure(a);
+
+	for (var key in b) {
+		if (b.hasOwnProperty(key)) {
+			test.ok(key === '0' || key === '1' || key === '2' || key === '3', 'Expected own property "0", "1", "2" or "3", but found: ' + key);
+		}
+	}
+
 	test.ok(instanceOf(b, Tome), 'expected Tome');
 	test.ok(instanceOf(b, ArrayTome), 'expected ArrayTome');
 	test.ok(notInstanceOf(b, BooleanTome), 'expected not BooleanTome');

--- a/test/modules/object.js
+++ b/test/modules/object.js
@@ -35,7 +35,22 @@ exports.testObjectCreation = function (test) {
 	test.ok(notInstanceOf(b, StringTome)); // 8
 	test.ok(notInstanceOf(b, NullTome)); // 9
 	test.ok(notInstanceOf(b, UndefinedTome)); // 10
-	
+
+	test.done();
+};
+
+exports.testEnumeration = function (test) {
+	var a = { a: 0, b: 1, c: 2 };
+	var b = Tome.conjure(a);
+
+	test.deepEqual(Object.keys(b).sort(), Object.keys(a).sort());
+
+	for (var key in b) {
+		if (b.hasOwnProperty(key)) {
+			test.ok(key === 'a' || key === 'b' || key === 'c', 'Expected own property "a", "b" or "c", but found: ' + key);
+		}
+	}
+
 	test.done();
 };
 


### PR DESCRIPTION
Like #44 and https://bugs.chromium.org/p/v8/issues/detail?id=4903, enumerables show up when they shouldn't in exactly the same pattern (when pre-initialized on the prototype object). This unit test fails. Now we need a solution :'(

Update: I've overridden `hasOwnProperty` on object and array tomes to behave well in for-in loops. *Technically*, it's incorrect, since `myTome.hasOwnProperty('_events')` should return true, and the fact that it's not enumerable should keep it out of the for-in loop. But since we cannot fix the enumerable issue, enabling the hasOwnProperty filter to take these properties out of the equation during a for-in loop does solve the practical use-case. It's a total hack, but I see no alternatives.

Fixes #43